### PR TITLE
Fix bazel installer bash script

### DIFF
--- a/install-bazel.sh
+++ b/install-bazel.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
-RELEASE=3.6.0
+
+SCRIPT_DIR_NAME=$(cd "$(dirname "$0")" || exit 1; pwd -P)
+RELEASE="$(cat ${SCRIPT_DIR_NAME}/.bazelversion)"
+echo "Installing bazel ${RELEASE}"
 wget https://github.com/bazelbuild/bazel/releases/download/${RELEASE}/bazel-${RELEASE}-installer-linux-x86_64.sh
 wget https://github.com/bazelbuild/bazel/releases/download/${RELEASE}/bazel-${RELEASE}-installer-linux-x86_64.sh.sha256
 sha256sum -c bazel-${RELEASE}-installer-linux-x86_64.sh.sha256


### PR DESCRIPTION
The installed version has to exactly match the version in file `.bazelversion`. Otherwise, `bazel` command will report an error like the one below
```
ERROR: The project you're trying to build requires Bazel 3.7.2 (specified in .../.bazelversion), but it wasn't found in ...
```

## Test
```
$ git clone git@github.com:bazelment/trunk.git
$ cd trunk
$ mkdir bazel-install
$ cd bazel-install
$ ../install-bazel.sh
 ...
Installing bazel 3.7.2
...
$ cd .. && rm -fr bazel-install
$ bazel --version
bazel 3.7.2
```